### PR TITLE
Add min.io GA id to docs site.

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -13,7 +13,7 @@ Plugins:
       apiKey: "0ba0d26da4d1483f96c03fe508304a64"
       index: "minio"
       tag: "en"
-  - Google Analytics: "UA-56860620-7"
+  - Google Analytics: "UA-56860620-1"
   - HubSpot: "5728672"
   - Lead Forensics: "170286"
   - Footer Widget:

--- a/site_CN.yml
+++ b/site_CN.yml
@@ -12,7 +12,7 @@ Plugins:
       apiKey: "0ba0d26da4d1483f96c03fe508304a64"
       index: "minio"
       tag: "cn"
-  - Google Analytics: "UA-56860620-7"
+  - Google Analytics: "UA-56860620-1"
   - Footer Widget:
       Label: "Talk to community"
       Link: "https://slack.minio.io"


### PR DESCRIPTION
We wanted the same GA id in both min.io and docs site.