### PR TITLE
Move deployment higher in order of categories

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -176,6 +176,35 @@ Documents:
         SEO Keywords: Hadoop, HDFS, gateway, S3, HDFS S3
         Options: hidden
 
+  - MinIO Deployment:
+      - MinIO Deployment Quickstart Guide:
+        Link: https://raw.githubusercontent.com/minio/minio/master/docs/orchestration/README.md
+        Slug: minio-deployment-quickstart-guide
+        SEO Title: MinIO | MinIO Deployment Quickstart Guide
+        SEO Description: This guide covers deployment documentation for Orchestration platforms - Docker Swarm, Docker Compose, Kubernetes, DC/OS
+        SEO Keywords: Docker Swarm, Docker Compose, Kubernetes, DC/OS
+
+      - Deploy MinIO on Docker Swarm:
+        Link: https://raw.githubusercontent.com/minio/minio/master/docs/orchestration/docker-swarm/README.md
+        Slug: deploy-minio-on-docker-swarm
+        SEO Title: MinIO | Deploy MinIO on Docker Swarm
+        SEO Description: This guide covers how MinIO server can be easily deployed in distributed mode on Swarm to create a multi-tenant, highly-available and scalable object store.
+        SEO Keywords: Docker Swarm, Docker Compose
+
+      - Deploy MinIO on Kubernetes:
+        Link: https://raw.githubusercontent.com/minio/minio/master/docs/orchestration/kubernetes/README.md
+        Slug: deploy-minio-on-kubernetes
+        SEO Title: MinIO | Deploy MinIO on Kubernetes
+        SEO Description: This guide documents the multiple options to deploy MinIO on Kubernetes. Concepts like Deployments and StatefulSets MinIO in standalone, distributed or gateway mode.
+        SEO Keywords: kubernetes, statefulsets, helm chart repository
+
+      - Deploy MinIO on Docker Compose:
+        Link: https://raw.githubusercontent.com/minio/minio/master/docs/orchestration/docker-compose/README.md
+        Slug: deploy-minio-on-docker-compose
+        SEO Title: MinIO | Deploy MinIO on Docker Compose
+        SEO Description: This guide covers deployment of MinIO using Docker Compose. Compose allows defining and running single host, multi-container Docker applications.
+        SEO Keywords: Docker compose, distributed minio, single host, multi-container
+
   - MinIO Client:
       - MinIO Client Quickstart Guide:
         Link: https://raw.githubusercontent.com/minio/mc/master/README.md
@@ -458,39 +487,3 @@ Documents:
         SEO Title: MinIO | How to generate Let's Encrypt certificate using Certbot - Cookbook/Recipe
         SEO Description: In this recipe, we will generate a Let's Encrypt certificate using Certbot. This certificate will then be deployed for use in the MinIO server.
         SEO Keywords: Let's Encrypt, Certbot, Certificate Authority
-
-  - MinIO Deployment:
-      - MinIO Deployment Quickstart Guide:
-        Link: https://raw.githubusercontent.com/minio/minio/master/docs/orchestration/README.md
-        Slug: minio-deployment-quickstart-guide
-        SEO Title: MinIO | MinIO Deployment Quickstart Guide
-        SEO Description: This guide covers deployment documentation for Orchestration platforms - Docker Swarm, Docker Compose, Kubernetes, DC/OS
-        SEO Keywords: Docker Swarm, Docker Compose, Kubernetes, DC/OS
-
-      - Deploy MinIO on Docker Swarm:
-        Link: https://raw.githubusercontent.com/minio/minio/master/docs/orchestration/docker-swarm/README.md
-        Slug: deploy-minio-on-docker-swarm
-        SEO Title: MinIO | Deploy MinIO on Docker Swarm
-        SEO Description: This guide covers how MinIO server can be easily deployed in distributed mode on Swarm to create a multi-tenant, highly-available and scalable object store.
-        SEO Keywords: Docker Swarm, Docker Compose
-
-      - Deploy MinIO on Kubernetes:
-        Link: https://raw.githubusercontent.com/minio/minio/master/docs/orchestration/kubernetes/README.md
-        Slug: deploy-minio-on-kubernetes
-        SEO Title: MinIO | Deploy MinIO on Kubernetes
-        SEO Description: This guide documents the multiple options to deploy MinIO on Kubernetes. Concepts like Deployments and StatefulSets MinIO in standalone, distributed or gateway mode.
-        SEO Keywords: kubernetes, statefulsets, helm chart repository
-
-      - Deploy MinIO on DC/OS:
-        Link: https://raw.githubusercontent.com/minio/minio/master/docs/orchestration/dcos/README.md
-        Slug: deploy-minio-on-dc-os
-        SEO Title: MinIO | Deploy MinIO on DC/OS
-        SEO Description: This guide documents the deployment of MinIO on DC/OS
-        SEO Keywords: DC/OS, Marathon-LB
-
-      - Deploy MinIO on Docker Compose:
-        Link: https://raw.githubusercontent.com/minio/minio/master/docs/orchestration/docker-compose/README.md
-        Slug: deploy-minio-on-docker-compose
-        SEO Title: MinIO | Deploy MinIO on Docker Compose
-        SEO Description: This guide covers deployment of MinIO using Docker Compose. Compose allows defining and running single host, multi-container Docker applications.
-        SEO Keywords: Docker compose, distributed minio, single host, multi-container

--- a/site_CN.yml
+++ b/site_CN.yml
@@ -1,6 +1,6 @@
 Site: "MinIO Docs"
 Output: "cn"
-Logo: 
+Logo:
   Image: "https://min.io/resources/img/logo/MINIO_wordmark.png"
   Link: "https://min.io"
 
@@ -70,6 +70,23 @@ Documents:
       - MinIO磁盘缓存指南:
         Link: https://raw.githubusercontent.com/minio/minio/master/docs/zh_CN/disk-caching/README.md
         Slug: minio-disk-cache-guide
+
+  - MinIO部署: # MinIO Deployment
+      - MinIO部署快速入门:
+        Link: https://raw.githubusercontent.com/minio/minio/master/docs/zh_CN/orchestration/README.md
+        Slug: minio-deployment-quickstart-guide
+
+      - 使用Docker Swarm部署MinIO:
+        Link: https://raw.githubusercontent.com/minio/minio/master/docs/zh_CN/orchestration/docker-swarm/README.md
+        Slug: deploy-minio-on-docker-swarm
+
+      - 使用Kubernetes部署MinIO:
+        Link: https://raw.githubusercontent.com/minio/minio/master/docs/zh_CN/orchestration/kubernetes/README.md
+        Slug: deploy-minio-on-kubernetes
+
+      - 使用Docker Compose部署MinIO:
+        Link: https://raw.githubusercontent.com/minio/minio/master/docs/zh_CN/orchestration/docker-compose/README.md
+        Slug: deploy-minio-on-docker-compose
 
   - MinIO客户端: # MinIO Client
       - MinIO客户端快速入门指南:
@@ -225,24 +242,3 @@ Documents:
       - 如何使用aws-cli调用MinIO服务端加密:
         Link: https://raw.githubusercontent.com/minio/cookbook/master/docs/zh_CN/how-to-use-minio-server-side-encryption-with-aws-cli.md
         Slug: how-to-use-minio-s-server-side-encryption-with-aws-cli
-
-  - MinIO部署: # MinIO Deployment
-      - MinIO部署快速入门:
-        Link: https://raw.githubusercontent.com/minio/minio/master/docs/zh_CN/orchestration/README.md
-        Slug: minio-deployment-quickstart-guide
-
-      - 使用Docker Swarm部署MinIO:
-        Link: https://raw.githubusercontent.com/minio/minio/master/docs/zh_CN/orchestration/docker-swarm/README.md
-        Slug: deploy-minio-on-docker-swarm
-
-      - 使用Kubernetes部署MinIO:
-        Link: https://raw.githubusercontent.com/minio/minio/master/docs/zh_CN/orchestration/kubernetes/README.md
-        Slug: deploy-minio-on-kubernetes
-
-      - 在 DC/OS上部署MinIO:
-        Link: https://raw.githubusercontent.com/minio/minio/master/docs/zh_CN/orchestration/dcos/README.md
-        Slug: deploy-minio-on-dc-os
-
-      - 使用Docker Compose部署MinIO:
-        Link: https://raw.githubusercontent.com/minio/minio/master/docs/zh_CN/orchestration/docker-compose/README.md
-        Slug: deploy-minio-on-docker-compose


### PR DESCRIPTION
MinIO server deployment based on k8s, docker should
in higher order of categories not after cookbook.

This PR also removes DC/OS based deployments since
we do not maintain or support it anymore.

This is approved by @ab