### PR TITLE
Resize MinIO logo on Quickstart Guide

### DIFF
--- a/lib/scss/inc/_base.scss
+++ b/lib/scss/inc/_base.scss
@@ -120,6 +120,14 @@ blockquote {
     }
   }
 
+  a[href="https://min.io"] {
+    & > img:not([class]) {
+      @media (min-width: $screen-sm-min) {
+        width: 340px;
+      }
+    }
+  }
+
   ul:not([class]) {
     li {
       padding-bottom: 5px;


### PR DESCRIPTION
This commit adds a CSS rule to resize images in the content div
enclosed by a link tag with href attribute equal to "https://min.io".
This case is only applicable for the MinIO logo on the Quickstart Guide
at the moment.