### PR TITLE
Remove references to DC/OS from Orchestration page

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -213,8 +213,8 @@ Documents:
         Link: https://raw.githubusercontent.com/minio/minio/release/docs/orchestration/README.md
         Slug: minio-deployment-quickstart-guide
         SEO Title: MinIO | MinIO Deployment Quickstart Guide
-        SEO Description: This guide covers deployment documentation for Orchestration platforms - Docker Swarm, Docker Compose, Kubernetes, DC/OS
-        SEO Keywords: Docker Swarm, Docker Compose, Kubernetes, DC/OS
+        SEO Description: This guide covers deployment documentation for Orchestration platforms - Docker Swarm, Docker Compose, Kubernetes
+        SEO Keywords: Docker Swarm, Docker Compose, Kubernetes
 
       - Deploy MinIO on Docker Swarm:
         Link: https://raw.githubusercontent.com/minio/minio/release/docs/orchestration/docker-swarm/README.md


### PR DESCRIPTION
Looks like we removed references to DC/OS in an [earlier commit](https://github.com/minio/minio/commit/e45c90060f5228b269b1e3ab149e9ec15e4a239f#diff-e8e63fa7b12a8704d49b8eab4691c7c1), but there are a few residual references. 

I'm open to keeping the SEO, though am somewhat concerned about users landing on this page and not finding any information related to DC/OS. 